### PR TITLE
Equivalencia nombres y usuarios en Discord

### DIFF
--- a/nombres-discord
+++ b/nombres-discord
@@ -1,0 +1,4 @@
+Brian Leonardo = Brian Leonardo Melo Castro
+Lisandro=Lisandro Pascuali
+Lautaro=Lautaro Ramirez
+Cheli=Marcelino Zárate


### PR DESCRIPTION
Muchas veces nos encontramos perdidos en la penumbra, sin saber qué puerta tocar, a quién preguntar...al menos en este grupo ya no sucederá más.

Con esta nueva funcionalidad, nuestras preguntas que temían quedar estériles, tendrán una respuesta: desde el archivo <nombres-discord> encontraremos quién es quién en este grupo.

Por favor, os ruego que aprueben esta feature. =)